### PR TITLE
use env var for logs source from s3 for now

### DIFF
--- a/aws/logs_monitoring/lambda_function.py
+++ b/aws/logs_monitoring/lambda_function.py
@@ -730,7 +730,10 @@ def s3_handler(event, context, metadata):
     key = urllib.parse.unquote_plus(event["Records"][0]["s3"]["object"]["key"])
 
     source = parse_event_source(event, key)
-    metadata[DD_SOURCE] = source
+    if DD_SOURCE is not None:
+        metadata[DD_SOURCE] = DD_SOURCE
+    else:
+        metadata[DD_SOURCE] = source
     ##default service to source value
     metadata[DD_SERVICE] = source
     ##Get the ARN of the service and set it as the hostname


### PR DESCRIPTION
<!--- Please remember to review the [contribution guidelines](https://github.com/DataDog/datadog-serverless-functions/blob/master/CONTRIBUTING.md) if you have not yet done so._  --->

### What does this PR do?

This PR sets the `DD_SOURCE` (which in turn is used internally by DataDog as `ddsource`) to the env var set in the lambda environment, if present. Why? Because otherwise it is set to `s3` which isn't useful if your logs are from Cloudflare!

Note: this is not a good solution–I plan to make it smarter so that we can ingest both S3 and Cloudflare logs (via S3).
